### PR TITLE
various fixes and additions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sqlite-file-index',
-    version='1',
+    version='1.2',
     packages=find_packages(),
     url='',
     license='MIT',

--- a/sqlite_file_index/optional_generator.py
+++ b/sqlite_file_index/optional_generator.py
@@ -1,0 +1,77 @@
+from functools import wraps
+from inspect import isgeneratorfunction
+
+
+def optional_generator(func):
+    """
+    A function passed through this decorator will act as either an ordinary
+    function, or, if yields occur, as a generator.
+
+    :param func: a function
+
+    :return:
+    a wrapper that when called will return a generator
+    if yields occur, otherwise, the return value of the function.
+    """
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        call_result = func(*args, **kwargs)
+
+        if isgeneratorfunction(func):
+            try:
+                first_item = next(call_result)
+
+            except StopIteration as e:
+                try:
+                    return e.args[0]
+                except IndexError:
+                    return None
+
+            else:
+                @wraps(func)
+                def items():
+                    yield first_item
+                    yield from call_result
+
+                return items()
+
+        else:
+            return call_result
+
+    return wrapped
+
+
+# example code
+if __name__ == '__main__':
+    @optional_generator
+    def print_or_yield_range(count=3, is_generator=False):
+        result = []
+        for i in range(count):
+            if is_generator:
+                yield i
+            else:
+                result.append(i)
+
+        return result
+
+    as_function = print_or_yield_range(is_generator=False)
+    as_generator = print_or_yield_range(is_generator=True)
+
+    print('function returned:', as_function)
+    print('generator returned:', as_generator)
+    for item in as_generator:
+        print('generated:', item)
+
+# output
+# 0
+# 1
+# 2
+# 3
+# 4
+# function returned: lol
+# generator returned: <generator object print_or_yield_range at 0x000001ED11D51228>
+# generated: 0
+# generated: 1
+# generated: 2
+# generated: 3
+# generated: 4


### PR DESCRIPTION
- fixed the handling of the `yield_paths` parameter in `FileIndex.add_paths`
so that the function acts as a normal function when it's false
- fixed a mistake in `FileIndexNode.__get_parent_id` which caused an `IntegrityError`
- added the option to yield folders as well with `FileIndex.search`
- fixed various indentation inconsistencies
- added `FileIndex.get_root_nodes`, which returns all top level nodes in the
index.
- version upped to 1.2